### PR TITLE
ファイルの読み込みをCSV用に改修

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>spring-boot-devtools</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/Controller/ResultController.java
+++ b/src/main/java/com/example/Controller/ResultController.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,14 +50,22 @@ public class ResultController {
 	private List<String> fileContents(MultipartFile uploadFile) {
         List<String> lines = new ArrayList<String>();
         String line = null;
+        CSVParser parse = null;
         try {
             InputStream stream = uploadFile.getInputStream();
             Reader reader = new InputStreamReader(stream,"SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
             BufferedReader buf= new BufferedReader(reader);
-            while((line = buf.readLine()) != null) {
-                lines.add(line);
+
+            // CSVファイルをパース
+            parse = CSVFormat.EXCEL.withHeader().parse(buf);
+            // レコードのリストに変換
+            List<CSVRecord> recordList = parse.getRecords();
+            // 各レコードを標準出力に出力＆画面表示用のリストに格納
+            for (CSVRecord record : recordList) { //参考ページ：http://itref.fc2web.com/java/commons/csv.html
+                System.out.println(record);
+                String lastName = record.get("msg"); //test.csv用
+                lines.add(lastName);
             }
-            line = buf.readLine();
 
         } catch (IOException e) {
             line = "Can't read contents.";


### PR DESCRIPTION
## 概要
テキストファイル全般を読みこめるようにしていたが、今後のDBとの連携に備えてCSVに特化するよう改修する
https://github.com/TakuyaFukumura/radiviewer/issues/1
## 修正ポイント
- CSVファイルを扱うための外部ライブラリ？を依存関係に追加
- アップされたファイルの読み込み方式を変更

## スクリーンショット
![image](https://user-images.githubusercontent.com/53442938/104177211-c20f6000-544b-11eb-96da-1c7e026edaff.png)
