### PR TITLE
CSVから読み込んだデータをDTOに格納できるようにする

### DIFF
--- a/src/main/java/com/example/Controller/ResultController.java
+++ b/src/main/java/com/example/Controller/ResultController.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.Dto.DividendlistDto;
+
 /**
  * @author fukumura
  *
@@ -37,20 +39,19 @@ public class ResultController {
 	@PostMapping
 	public String index(@RequestParam("csv_file")MultipartFile csv_file, Map<String, Object> model) {
 		if(csv_file != null) {
-			List<String> contents = this.fileContents(csv_file);
+			List<DividendlistDto> contents = this.fileContents(csv_file);
 			model.put("contents", contents);
 		}
 		return "result";
 	}
 
-
     /*
      * ファイル内容を文字列化するメソッドです。
      */
-	private List<String> fileContents(MultipartFile uploadFile) {
-        List<String> lines = new ArrayList<String>();
-        String line = null;
+	private List<DividendlistDto> fileContents(MultipartFile uploadFile) {
         CSVParser parse = null;
+
+        List<DividendlistDto> dividendlistDtoList = new ArrayList<DividendlistDto>();
         try {
             InputStream stream = uploadFile.getInputStream();
             Reader reader = new InputStreamReader(stream,"SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
@@ -62,17 +63,20 @@ public class ResultController {
             List<CSVRecord> recordList = parse.getRecords();
             // 各レコードを標準出力に出力＆画面表示用のリストに格納
             for (CSVRecord record : recordList) { //参考ページ：http://itref.fc2web.com/java/commons/csv.html
-                System.out.println(record);
-                String lastName = record.get("msg"); //test.csv用
-                lines.add(lastName);
+            	DividendlistDto dividendlistDto = new DividendlistDto(record.get("入金日"),
+            			record.get("商品"),record.get("口座"),
+            			record.get("銘柄コード"),record.get("銘柄"),
+            			record.get("単価[円/現地通貨]"),record.get("数量[株/口]"),
+            			record.get("配当・分配金合計（税引前）[円/現地通貨]"),
+            			record.get("税額合計[円/現地通貨]"),record.get("受取金額[円/現地通貨]"));
+
+                dividendlistDtoList.add(dividendlistDto);
             }
 
-        } catch (IOException e) {
-            line = "Can't read contents.";
-            lines.add(line);
+        } catch (IOException e) { // csv読み込み失敗時
             e.printStackTrace();
         }
-        return lines;
+        return dividendlistDtoList;
     }
 
 }

--- a/src/main/java/com/example/Dto/DividendlistDto.java
+++ b/src/main/java/com/example/Dto/DividendlistDto.java
@@ -1,0 +1,292 @@
+/**
+ *
+ */
+package com.example.Dto;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/*
+ * 入金日,	"2021/01/07"	日付型	Date
+ * 商品,	"米国株式",	文字型10文字	String
+ * 口座,	"NISA",	文字型8文字	String
+ * 銘柄コード,	"HYEM",	文字5文字	String
+ * 銘柄,	"VV EM HY BOND",	文字50文字	String
+ * 単価[円/現地通貨],	"0.1139",	数値小数点以下5桁うえ7桁	BigDecimal
+ * 数量[株/口],	"1",	数値10桁	BigDecimal
+ * 配当・分配金合計（税引前）[円/現地通貨],	"0.11",	数値しも2桁うえ10桁	BigDecimal
+ * 税額合計[円/現地通貨],	"0",	数値しも2桁うえ10桁	BigDecimal
+ * 受取金額[円/現地通貨]	,"0.10"	数値しも2桁うえ10桁	BigDecimal
+ */
+
+/**
+ * @author fukumura
+ *
+ */
+public class DividendlistDto {
+	private Date paymentDay;
+	private String product;
+	private String account;
+	private String issueCode;
+	private String issue;
+	private BigDecimal unitPrice;
+	private BigDecimal unit;
+	private BigDecimal beforeTaxDividendIncome;
+	private BigDecimal tax;
+	private BigDecimal afterTaxDividendIncome;
+
+	private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd");
+
+	public DividendlistDto() {
+
+	}
+	/**
+	 * @param paymentDay
+	 * @param product
+	 * @param account
+	 * @param issueCode
+	 * @param issue
+	 * @param unitPrice
+	 * @param unit
+	 * @param beforeTaxDividendIncome
+	 * @param tax
+	 * @param afterTaxDividendIncome
+	 */
+	public DividendlistDto(Date paymentDay, String product,
+			String account, String issueCode, String issue,
+			BigDecimal unitPrice, BigDecimal unit,
+			BigDecimal beforeTaxDividendIncome, BigDecimal tax,
+			BigDecimal afterTaxDividendIncome) {
+		super();
+		this.paymentDay = paymentDay;
+		this.product = product;
+		this.account = account;
+		this.issueCode = issueCode;
+		this.issue = issue;
+		this.unitPrice = unitPrice;
+		this.unit = unit;
+		this.beforeTaxDividendIncome = beforeTaxDividendIncome;
+		this.tax = tax;
+		this.afterTaxDividendIncome = afterTaxDividendIncome;
+	}
+	/**
+	 * @param paymentDay
+	 * @param product
+	 * @param account
+	 * @param issueCode
+	 * @param issue
+	 * @param unitPrice
+	 * @param unit
+	 * @param beforeTaxDividendIncome
+	 * @param tax
+	 * @param afterTaxDividendIncome
+	 */
+	public DividendlistDto(String paymentDay, String product, String account, String issueCode, String issue,
+			String unitPrice, String unit, String beforeTaxDividendIncome, String tax,
+			String afterTaxDividendIncome) {
+		super();
+		try {
+			this.paymentDay = dateFormat.parse(paymentDay);
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+		this.product = product;
+		this.account = account;
+		this.issueCode = issueCode;
+		this.issue = issue;
+		this.unitPrice = convStrToBigDecimal(unitPrice);
+		this.unit = convStrToBigDecimal(unit);
+		this.beforeTaxDividendIncome = convStrToBigDecimal(beforeTaxDividendIncome);
+		this.tax = convStrToBigDecimal(tax);
+		this.afterTaxDividendIncome = convStrToBigDecimal(afterTaxDividendIncome);
+	}
+	/**
+	 * @return paymentDay
+	 */
+	public Date getPaymentDay() {
+		return paymentDay;
+	}
+	/**
+	 * @param paymentDay セットする paymentDay
+	 */
+	public void setPaymentDay(Date paymentDay) {
+		this.paymentDay = paymentDay;
+	}
+	/**
+	 * @param paymentDay セットする paymentDay
+	 */
+	public void setPaymentDay(String paymentDay) {
+		try {
+			this.paymentDay = dateFormat.parse(paymentDay);
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+	}
+	/**
+	 * @return product
+	 */
+	public String getProduct() {
+		return product;
+	}
+	/**
+	 * @param product セットする product
+	 */
+	public void setProduct(String product) {
+		this.product = product;
+	}
+	/**
+	 * @return account
+	 */
+	public String getAccount() {
+		return account;
+	}
+	/**
+	 * @param account セットする account
+	 */
+	public void setAccount(String account) {
+		this.account = account;
+	}
+	/**
+	 * @return issueCode
+	 */
+	public String getIssueCode() {
+		return issueCode;
+	}
+	/**
+	 * @param issueCode セットする issueCode
+	 */
+	public void setIssueCode(String issueCode) {
+		this.issueCode = issueCode;
+	}
+	/**
+	 * @return issue
+	 */
+	public String getIssue() {
+		return issue;
+	}
+	/**
+	 * @param issue セットする issue
+	 */
+	public void setIssue(String issue) {
+		this.issue = issue;
+	}
+	/**
+	 * @return unitPrice
+	 */
+	public BigDecimal getUnitPrice() {
+		return unitPrice;
+	}
+	/**
+	 * @param unitPrice セットする unitPrice
+	 */
+	public void setUnitPrice(BigDecimal unitPrice) {
+		this.unitPrice = unitPrice;
+	}
+	/**
+	 * @param unitPrice セットする unitPrice
+	 */
+	public void setUnitPrice(String unitPrice) {
+		this.unitPrice = convStrToBigDecimal(unitPrice);
+	}
+	/**
+	 * @return unit
+	 */
+	public BigDecimal getUnit() {
+		return unit;
+	}
+	/**
+	 * @param unit セットする unit
+	 */
+	public void setUnit(BigDecimal unit) {
+		this.unit = unit;
+	}
+	/**
+	 * @param unit セットする unit
+	 */
+	public void setUnit(String unit) {
+		this.unit = convStrToBigDecimal(unit);
+	}
+	/**
+	 * @return beforeTaxDividendIncome
+	 */
+	public BigDecimal getBeforeTaxDividendIncome() {
+		return beforeTaxDividendIncome;
+	}
+	/**
+	 * @param beforeTaxDividendIncome セットする beforeTaxDividendIncome
+	 */
+	public void setBeforeTaxDividendIncome(BigDecimal beforeTaxDividendIncome) {
+		this.beforeTaxDividendIncome = beforeTaxDividendIncome;
+	}
+	/**
+	 * @param beforeTaxDividendIncome セットする beforeTaxDividendIncome
+	 */
+	public void setBeforeTaxDividendIncome(String beforeTaxDividendIncome) {
+		this.beforeTaxDividendIncome = convStrToBigDecimal(beforeTaxDividendIncome);
+	}
+	/**
+	 * @return tax
+	 */
+	public BigDecimal getTax() {
+		return tax;
+	}
+	/**
+	 * @param tax セットする tax
+	 */
+	public void setTax(BigDecimal tax) {
+		this.tax = tax;
+	}
+	/**
+	 * @param tax セットする tax
+	 */
+	public void setTax(String tax) {
+		this.tax = convStrToBigDecimal(tax);
+	}
+	/**
+	 * @return afterTaxDividendIncome
+	 */
+	public BigDecimal getAfterTaxDividendIncome() {
+		return afterTaxDividendIncome;
+	}
+	/**
+	 * @param afterTaxDividendIncome セットする afterTaxDividendIncome
+	 */
+	public void setAfterTaxDividendIncome(BigDecimal afterTaxDividendIncome) {
+		this.afterTaxDividendIncome = afterTaxDividendIncome;
+	}
+	/**
+	 * @param afterTaxDividendIncome セットする afterTaxDividendIncome
+	 */
+	public void setAfterTaxDividendIncome(String afterTaxDividendIncome) {
+		this.afterTaxDividendIncome = convStrToBigDecimal(afterTaxDividendIncome);
+	}
+
+	/*
+	 * 文字列で表された数値をBigDecimal型に変換する
+	 */
+	public BigDecimal convStrToBigDecimal(String str) {
+		BigDecimal tmpNum = new BigDecimal(0);
+		DecimalFormat decimalFormat = new DecimalFormat();
+		decimalFormat.setParseBigDecimal(true);
+
+		if( !str.isEmpty() ) {
+			try {
+				tmpNum = (BigDecimal) decimalFormat.parse(str);
+			} catch (ParseException e) {
+				e.printStackTrace();
+			}
+		}
+
+		return tmpNum;
+	}
+
+
+}
+/*内容の例
+ * 入金日,商品,口座,銘柄コード,銘柄,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]
+"2021/01/07","米国株式","NISA","HYEM","VV EM HY BOND","0.1139","1","0.11","0","0.10"
+"2021/01/04","投資信託","特定","","ブラジル株式ツインαファンド(毎月分配型)ツインα・コース","20.00","3,683","7","0","7"
+ */

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -3,9 +3,32 @@
 	th:replace="~{fragments/layout :: layout (~{::body},'result')}">
 
 <body>
-	アップ成功？
-	<ul th:each="content : ${contents}">
-		<li th:text="${content}" />
-	</ul>
+	一覧表
+	<table border="1">
+    <tr>
+      <th>入金日</th>
+      <th>商品</th>
+      <th>口座</th>
+      <th>銘柄コード</th>
+      <th>銘柄</th>
+      <th>単価[円/現地通貨]</th>
+      <th>数量[株/口]</th>
+      <th>配当・分配金合計（税引前）[円/現地通貨]</th>
+      <th>税額合計[円/現地通貨]</th>
+      <th>受取金額[円/現地通貨]</th>
+    </tr>
+    <tr th:each="content : ${contents}">
+      <td th:text="${content.getPaymentDay()}"></td>
+      <td>[[${content.getProduct()}]]</td>
+      <td th:text="${content.getAccount()}"></td>
+      <td th:text="${content.getIssueCode()}"></td>
+      <td th:text="${content.getIssue()}"></td>
+      <td th:text="${content.getUnitPrice()}"></td>
+      <td th:text="${content.getUnit()}"></td>
+      <td th:text="${content.getBeforeTaxDividendIncome()}"></td>
+      <td th:text="${content.getTax()}"></td>
+      <td th:text="${content.getAfterTaxDividendIncome()}"></td>
+    </tr>
+  </table>
 </body>
 </html>


### PR DESCRIPTION
対応issue：https://github.com/TakuyaFukumura/radiviewer/issues/2
## 概要
楽天証券の配当CSVのデータ用のDTOを作成する

## 修正ポイント
- 楽天証券配当CSV用のDTO作成
- コントローラで上記DTOを使用するように変更
- result.htmlでDTOの中身を表形式で表示するように変更

## 動作確認
CSVのデータを一旦DTOに格納、その後HTML側で表示まで出来ることを確認した

## スクリーンショット
![image](https://user-images.githubusercontent.com/53442938/105029353-987eb600-5a95-11eb-99fc-e05862fb4248.png)
