### PR TITLE
一覧画面改名

### DIFF
--- a/src/main/java/com/example/Controller/TableController.java
+++ b/src/main/java/com/example/Controller/TableController.java
@@ -28,8 +28,8 @@ import com.example.Dto.DividendDto;
  *
  */
 @Controller
-@RequestMapping("/result")
-public class ResultController {
+@RequestMapping("/table")
+public class TableController {
 
 	/*
 	 * 参考ページ
@@ -42,7 +42,7 @@ public class ResultController {
 			List<DividendDto> contents = this.fileContents(csv_file);
 			model.put("contents", contents);
 		}
-		return "result";
+		return "table";
 	}
 
     /*

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,7 +3,7 @@
 
 <body>
 	楽天証券の配当金・分配金一覧csvファイルを選択してください
-	<form action="/result" method="post" enctype="multipart/form-data">
+	<form action="/table" method="post" enctype="multipart/form-data">
 		<input type="file" name="csv_file"  accept=".csv">
 		<button type="submit">送信する</button>
 	</form>

--- a/src/main/resources/templates/table.html
+++ b/src/main/resources/templates/table.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-	th:replace="~{fragments/layout :: layout (~{::body},'result')}">
+	th:replace="~{fragments/layout :: layout (~{::body},'table')}">
 
 <body>
 	一覧表


### PR DESCRIPTION
対応issue：https://github.com/TakuyaFukumura/radiviewer/issues/12
## 概要
画面の役割に適した名前へ変更

## 修正ポイント
- result.htmlをtable.htmlに変更
- コントローラ名もTableContllorerに変更
- 関連個所修正

## 動作確認
ローカルで正常に動作することを確認済み