### PR TITLE
ビジネスロジックをコントローラから分離する

### DIFF
--- a/src/main/java/com/example/Controller/TableController.java
+++ b/src/main/java/com/example/Controller/TableController.java
@@ -3,18 +3,9 @@
  */
 package com.example.Controller;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.Dto.DividendDto;
+import com.example.Logic.TableLogic;
 
 /**
  * @author fukumura
@@ -30,6 +22,7 @@ import com.example.Dto.DividendDto;
 @Controller
 @RequestMapping("/table")
 public class TableController {
+	TableLogic tableLogic = new TableLogic();
 
 	/*
 	 * 参考ページ
@@ -39,44 +32,9 @@ public class TableController {
 	@PostMapping
 	public String index(@RequestParam("csv_file")MultipartFile csv_file, Map<String, Object> model) {
 		if(csv_file != null) {
-			List<DividendDto> contents = this.fileContents(csv_file);
-			model.put("contents", contents);
+			List<DividendDto> contents = tableLogic.fileContents(csv_file);
+			model.put("contents", contents); // html側にデータ送るやつ
 		}
 		return "table";
 	}
-
-    /*
-     * ファイル内容を文字列化するメソッドです。
-     */
-	private List<DividendDto> fileContents(MultipartFile uploadFile) {
-        CSVParser parse = null;
-
-        List<DividendDto> dividendDtoList = new ArrayList<DividendDto>();
-        try {
-            InputStream stream = uploadFile.getInputStream();
-            Reader reader = new InputStreamReader(stream,"SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
-            BufferedReader buf= new BufferedReader(reader);
-
-            // CSVファイルをパース
-            parse = CSVFormat.EXCEL.withHeader().parse(buf);
-            // レコードのリストに変換
-            List<CSVRecord> recordList = parse.getRecords();
-            // 各レコードを標準出力に出力＆画面表示用のリストに格納
-            for (CSVRecord record : recordList) { //参考ページ：http://itref.fc2web.com/java/commons/csv.html
-            	DividendDto dividendDto = new DividendDto(record.get("入金日"),
-            			record.get("商品"),record.get("口座"),
-            			record.get("銘柄コード"),record.get("銘柄"),
-            			record.get("単価[円/現地通貨]"),record.get("数量[株/口]"),
-            			record.get("配当・分配金合計（税引前）[円/現地通貨]"),
-            			record.get("税額合計[円/現地通貨]"),record.get("受取金額[円/現地通貨]"));
-
-                dividendDtoList.add(dividendDto);
-            }
-
-        } catch (IOException e) { // csv読み込み失敗時
-            e.printStackTrace();
-        }
-        return dividendDtoList;
-    }
-
 }

--- a/src/main/java/com/example/Logic/TableLogic.java
+++ b/src/main/java/com/example/Logic/TableLogic.java
@@ -1,0 +1,61 @@
+/**
+ *
+ */
+package com.example.Logic;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.Dto.DividendDto;
+
+/**
+ * @author fukumura
+ *
+ */
+public class TableLogic {
+	/**
+	 * ファイル内容を文字列化するメソッドです。
+	 * @param uploadFile 読みこんだCSVデータ
+	 * @return dividendDtoList 配当CSVを読みこんだリスト
+	 */
+	public List<DividendDto> fileContents(MultipartFile uploadFile) {
+        CSVParser parse = null;
+
+        List<DividendDto> dividendDtoList = new ArrayList<DividendDto>(); //格納用のリスト
+        try {
+            InputStream stream = uploadFile.getInputStream();
+            Reader reader = new InputStreamReader(stream,"SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
+            BufferedReader buf= new BufferedReader(reader);
+
+            // CSVファイルをパース
+            parse = CSVFormat.EXCEL.withHeader().parse(buf);
+            // レコードのリストに変換
+            List<CSVRecord> recordList = parse.getRecords();
+            // 各レコードを標準出力に出力＆画面表示用のリストに格納
+            for (CSVRecord record : recordList) { //参考ページ：http://itref.fc2web.com/java/commons/csv.html
+            	DividendDto dividendDto = new DividendDto(record.get("入金日"),
+            			record.get("商品"),record.get("口座"),
+            			record.get("銘柄コード"),record.get("銘柄"),
+            			record.get("単価[円/現地通貨]"),record.get("数量[株/口]"),
+            			record.get("配当・分配金合計（税引前）[円/現地通貨]"),
+            			record.get("税額合計[円/現地通貨]"),record.get("受取金額[円/現地通貨]"));
+
+                dividendDtoList.add(dividendDto); // リストに加える
+            }
+        } catch (IOException e) { // csv読み込み失敗時
+            e.printStackTrace();
+        }
+        return dividendDtoList; // CSVの内容を読みこんだ一覧データを返す
+    }
+
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,7 +5,7 @@
 	楽天証券の配当金・分配金一覧csvファイルを選択してください
 	<form action="/table" method="post" enctype="multipart/form-data">
 		<input type="file" name="csv_file"  accept=".csv">
-		<button type="submit">送信する</button>
+		<button type="submit">一覧表示する</button>
 	</form>
 </body>
 </html>


### PR DESCRIPTION
対応issue：https://github.com/TakuyaFukumura/radiviewer/issues/8
## 概要
コントローラー内にロジックを書き込んでいたため別クラスに分離する

## 修正ポイント
- CSVを読みこんでリストに格納する処理をTableCntllorerから切り出してTableLogicクラスに記述
- ボタンの表記を適切なものに変更
  - 動作確認中に気になったため修正に含めました

## 動作確認
ローカル環境で動作することを確かめました