### PR TITLE
日付フォーマット追加

### DIFF
--- a/src/main/java/com/example/Dto/DividendDto.java
+++ b/src/main/java/com/example/Dto/DividendDto.java
@@ -110,6 +110,24 @@ public class DividendDto {
 		return paymentDay;
 	}
 	/**
+	 * フォーマットを適用して文字列型で返す<br>
+	 * true "yyyy/MM/dd"<br>
+	 * false "yyyy-MM-dd"
+	 * @param flag
+	 * @return paymentDay
+	 */
+	public String getPaymentDay(boolean flag) {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		String strDate = "";
+		if(flag) {
+			dateFormat = new SimpleDateFormat("yyyy/MM/dd");
+			strDate = dateFormat.format(paymentDay);
+		}else {
+			strDate = dateFormat.format(paymentDay);
+		}
+		return strDate;
+	}
+	/**
 	 * @param paymentDay セットする paymentDay
 	 */
 	public void setPaymentDay(Date paymentDay) {

--- a/src/main/resources/templates/table.html
+++ b/src/main/resources/templates/table.html
@@ -18,7 +18,7 @@
       <th>受取金額[円/現地通貨]</th>
     </tr>
     <tr th:each="content : ${contents}">
-      <td th:text="${content.getPaymentDay()}"></td>
+      <td th:text="${content.getPaymentDay(true)}"></td>
       <td>[[${content.getProduct()}]]</td>
       <td th:text="${content.getAccount()}"></td>
       <td th:text="${content.getIssueCode()}"></td>


### PR DESCRIPTION
対応issue：https://github.com/TakuyaFukumura/radiviewer/issues/7
## 概要

## 修正ポイント
- ゲッターをオーバーライドして日付を文字列型で返すメソッドを作成
  - 引数はboolean型で2種類のフォーマットを用意した
    - true `yyyy/mm/dd`
    - false `yyyy-mm-dd`
- 一覧表示時にフォーマットを適用するように変更
## 動作確認
ローカルで正しく表示されることを確認済み
## スクリーンショット
![image](https://user-images.githubusercontent.com/53442938/105184858-2e3c4300-5b73-11eb-8e51-58a87c90e301.png)
