### PR TITLE
配当金を棒グラフで表示する

### DIFF
--- a/src/main/java/com/example/Controller/BarGraphController.java
+++ b/src/main/java/com/example/Controller/BarGraphController.java
@@ -1,0 +1,51 @@
+/**
+ *
+ */
+package com.example.Controller;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.Dto.DividendDto;
+import com.example.Logic.BarGraphLogic;
+
+/**
+ * @author fukumura
+ *
+ */
+@Controller
+@RequestMapping("/barGraph")
+public class BarGraphController {
+	BarGraphLogic barGraphLogic = new BarGraphLogic();
+
+	@Autowired
+	HttpSession session;
+
+	/*
+	 * 参考ページ
+	 * https://qiita.com/nvtomo1029/items/316c5e8fe5d0cd92339c
+	 * https://qiita.com/misskabu/items/81fa2c774f92c63125b5
+	 */
+	@PostMapping
+	public String index( Map<String, Object> model) {
+
+		@SuppressWarnings("unchecked")
+		List<DividendDto> dividendDtoList = (List<DividendDto>) session.getAttribute("dividendDtoList");  // 取得
+
+		//session.invalidate(); // クリア
+
+		if(dividendDtoList != null) {
+			String[] deta = barGraphLogic.getCartData(dividendDtoList);
+			model.put("contents", deta); // html側にデータ送るやつ
+		}
+
+		return "barGraph";
+	}
+}

--- a/src/main/java/com/example/Controller/TableController.java
+++ b/src/main/java/com/example/Controller/TableController.java
@@ -6,6 +6,9 @@ package com.example.Controller;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,9 @@ import com.example.Logic.TableLogic;
 public class TableController {
 	TableLogic tableLogic = new TableLogic();
 
+	@Autowired
+	HttpSession session;
+
 	/*
 	 * 参考ページ
 	 * https://qiita.com/nvtomo1029/items/316c5e8fe5d0cd92339c
@@ -34,6 +40,7 @@ public class TableController {
 		if(csv_file != null) {
 			List<DividendDto> contents = tableLogic.fileContents(csv_file);
 			model.put("contents", contents); // html側にデータ送るやつ
+			session.setAttribute("dividendDtoList", contents);
 		}
 		return "table";
 	}

--- a/src/main/java/com/example/Dto/DividendDto.java
+++ b/src/main/java/com/example/Dto/DividendDto.java
@@ -112,12 +112,12 @@ public class DividendDto {
 	/**
 	 * フォーマットを適用して文字列型で返す<br>
 	 * true "yyyy/MM/dd"<br>
-	 * false "yyyy-MM-dd"
+	 * false "yyyyMM"
 	 * @param flag
 	 * @return paymentDay
 	 */
 	public String getPaymentDay(boolean flag) {
-		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMM");
 		String strDate = "";
 		if(flag) {
 			dateFormat = new SimpleDateFormat("yyyy/MM/dd");

--- a/src/main/java/com/example/Logic/BarGraphLogic.java
+++ b/src/main/java/com/example/Logic/BarGraphLogic.java
@@ -1,0 +1,90 @@
+/**
+ *
+ */
+package com.example.Logic;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.example.Dto.DividendDto;
+
+/**
+ * @author fukumura
+ *
+ */
+public class BarGraphLogic {
+	static int[] years = { 2019, 2020, 2021};
+
+	/**
+	 * 配当データのリストから棒グラフ描画用の
+	 * 文字列を生成して返します。<br>
+	 * 生成するのは2019年～2021年の3年分です
+	 * @param dividendDtoList 配当データリスト
+	 * @return contents グラフ描画用データ配列
+	 */
+	public String[] getCartData( List<DividendDto> dividendDtoList ) {
+		String data[] = new String[3];
+		for(int i = 0; i < years.length; i++) {
+			String[] temp = getMonthlyIncome(years[i], dividendDtoList);
+			data[i] = createCartData(temp);
+		}
+		return data;
+	}
+
+	/**
+	 * 指定した年の月別配当受取合計額をString配列で取得します
+	 * @param year 取得したい年（西暦）
+	 * @param dividendDtoList 配当データリスト
+	 * @return monthlyDividend 月別の配当受取額
+	 */
+	public String[] getMonthlyIncome( int year , List<DividendDto> dividendDtoList ) {
+		String[] monthlyDividend = new String[12];
+		String[] month = {"01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"};
+		BigDecimal sum = new BigDecimal(0);
+		BigDecimal afterTaxDividendIncome = new BigDecimal(0);
+
+		for(int i = 0; i < month.length; i++) {
+			sum = new BigDecimal(0);
+	        for(DividendDto dividendDto : dividendDtoList){ // 拡張for文
+	        	if( (year + month[i]).equals(dividendDto.getPaymentDay(false))) { //年月が一致しているかどうか
+	        		afterTaxDividendIncome = exchange(dividendDto); //米国株式なら×100する
+	        		sum = sum.add(afterTaxDividendIncome); //合計する
+	        	}
+	        }
+	        monthlyDividend[i] = sum.toString(); //月配当受取額を文字列変換
+		}
+		return monthlyDividend;
+	}
+
+	/**
+	 * ドルは円にして、円は円のまま数値を返します
+	 * @param dividendDto 個別配当情報
+	 * @return afterTaxDividendIncome 税引き後、為替適用後配当受取額
+	 */
+	public BigDecimal exchange(DividendDto dividendDto) {
+		BigDecimal afterTaxDividendIncome = dividendDto.getAfterTaxDividendIncome();
+		BigDecimal exchangeRate = new BigDecimal(100);
+		if("米国株式".contentEquals(dividendDto.getProduct())) {
+			afterTaxDividendIncome = afterTaxDividendIncome.multiply(exchangeRate);
+		}
+		return afterTaxDividendIncome;
+	}
+
+	/**
+	 * 文字列の配列を一つの文字列に合成します<br>
+	 * なお、合成する際には各要素の間に「,」を入れます<br>
+	 * 例： " 0.7, 2.2, 4.0"<br>
+	 * @param getSumIncomeList 月毎配当額情報 文字列配列型
+	 * @return Stringグラフ描画用文字列
+	 */
+	public String createCartData(String[] monthlyDividend) {
+		String result = "";
+		result += monthlyDividend[0];
+		for(int i = 1; i < monthlyDividend.length; i++) {
+			result += ",";
+			result += monthlyDividend[i];
+		}
+		return result;
+	}
+
+}

--- a/src/main/resources/templates/barGraph.html
+++ b/src/main/resources/templates/barGraph.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{fragments/layout :: layout (~{::body},'barGraph')}">
+
+<body>
+	<h1>棒グラフ</h1>
+	USD/JPY 100 で計算しています。<br>
+	<canvas id="barChart"></canvas>
+	<script
+		src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+
+	<script>
+		var ctx = document.getElementById("barChart");
+		var myBarChart = new Chart(ctx, {
+			type : 'bar',
+			data : {
+				labels : [ "1月","2月","3月","4月","5月","6月","7月",
+			    	  "8月", "9月", "10月", "11月", "12月" ],
+				datasets : [ {
+					label : '2019年 配当受取額',
+					data : [ [[${contents[0]}]] ],
+					backgroundColor : "rgba(219,39,91,0.5)"
+				}, {
+					label : '2020年 配当受取額',
+					data : [ [[${contents[1]}]] ],
+					backgroundColor : "rgba(130,201,169,0.5)"
+				}, {
+					label : '2021年 配当受取額',
+					data : [ [[${contents[2]}]] ],
+					backgroundColor : "rgba(255,183,76,0.5)"
+				} ]
+			},
+			options : {
+				title : {
+					display : true,
+					text : '月別配当受取額  年比較グラフ'
+				},
+				scales : {
+					yAxes : [ {
+						ticks : {
+							suggestedMax : 100,
+							suggestedMin : 0,
+							stepSize : 10,
+							callback : function(value, index, values) {
+								return value + '円'
+							}
+						}
+					} ]
+				},
+			}
+		});
+	</script>
+</body>
+</html>

--- a/src/main/resources/templates/table.html
+++ b/src/main/resources/templates/table.html
@@ -4,6 +4,9 @@
 
 <body>
 	一覧表
+	<form action="/barGraph" method="post" enctype="multipart/form-data">
+		<button type="submit">グラフ表示する</button>
+	</form>
 	<table border="1">
     <tr>
       <th>入金日</th>


### PR DESCRIPTION
## 概要
配当金を棒グラフ化して表示できるようにします

## 修正ポイント
- 棒グラフのviewを追加
  - グラフ描画にはChart.jsを使用
- 棒グラフ用コントローラ追加
- 棒グラフ用モデル追加
- 配当一覧画面に棒グラフ画面へ遷移するボタンを設置
- 配当データはセッションスコープで管理するように変更
## 動作確認
ローカルで正常に動かせることを確認
## スクリーンショット
![image](https://user-images.githubusercontent.com/53442938/105567233-0667fd80-5d74-11eb-9658-82b6d72bf38e.png)
