### PR TITLE
メニュー画面追加

### DIFF
--- a/src/main/java/com/example/Controller/BarGraphController.java
+++ b/src/main/java/com/example/Controller/BarGraphController.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.Dto.DividendDto;
@@ -33,7 +33,7 @@ public class BarGraphController {
 	 * https://qiita.com/nvtomo1029/items/316c5e8fe5d0cd92339c
 	 * https://qiita.com/misskabu/items/81fa2c774f92c63125b5
 	 */
-	@PostMapping
+	@GetMapping
 	public String index( Map<String, Object> model) {
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/com/example/Controller/MenuController.java
+++ b/src/main/java/com/example/Controller/MenuController.java
@@ -1,0 +1,51 @@
+/**
+ *
+ */
+package com.example.Controller;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.Dto.DividendDto;
+import com.example.Logic.TableLogic;
+
+/**
+ * @author fukumura
+ *
+ */
+@Controller
+@RequestMapping("/menu")
+public class MenuController {
+	TableLogic tableLogic = new TableLogic();
+
+	@Autowired
+	HttpSession session;
+
+	/*
+	 * 参考ページ
+	 * https://qiita.com/nvtomo1029/items/316c5e8fe5d0cd92339c
+	 * https://qiita.com/misskabu/items/81fa2c774f92c63125b5
+	 */
+	@PostMapping
+	public String index(@RequestParam("csv_file")MultipartFile csv_file, Map<String, Object> model) {
+		List<DividendDto> contents = tableLogic.fileContents(csv_file);
+		session.setAttribute("dividendDtoList", contents);
+		return "menu";
+	}
+
+	@GetMapping
+	public String indexGet( Map<String, Object> model) {
+		//データがあるかどうかチェック
+		return "menu";
+	}
+}

--- a/src/main/java/com/example/Controller/TableController.java
+++ b/src/main/java/com/example/Controller/TableController.java
@@ -10,10 +10,8 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.example.Dto.DividendDto;
 import com.example.Logic.TableLogic;
@@ -35,13 +33,13 @@ public class TableController {
 	 * https://qiita.com/nvtomo1029/items/316c5e8fe5d0cd92339c
 	 * https://qiita.com/misskabu/items/81fa2c774f92c63125b5
 	 */
-	@PostMapping
-	public String index(@RequestParam("csv_file")MultipartFile csv_file, Map<String, Object> model) {
-		if(csv_file != null) {
-			List<DividendDto> contents = tableLogic.fileContents(csv_file);
-			model.put("contents", contents); // html側にデータ送るやつ
-			session.setAttribute("dividendDtoList", contents);
-		}
+	@GetMapping
+	public String index( Map<String, Object> model ) {
+		@SuppressWarnings("unchecked")
+		List<DividendDto> dividendDtoList = (List<DividendDto>) session.getAttribute("dividendDtoList");
+
+		model.put("contents", dividendDtoList); // html側にデータ送るやつ
+
 		return "table";
 	}
 }

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -16,8 +16,16 @@
 
 package com.example;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+import javax.sql.DataSource;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -26,13 +34,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Map;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 @Controller
 @SpringBootApplication
@@ -44,13 +47,17 @@ public class Main {
   @Autowired
   private DataSource dataSource;
 
+  @Autowired
+  HttpSession session;
+
   public static void main(String[] args) throws Exception {
     SpringApplication.run(Main.class, args);
   }
 
   @RequestMapping("/")
   String index() {
-    return "index";
+	  session.invalidate(); // クリア
+	  return "index";
   }
 
   @RequestMapping("/db")

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -6,7 +6,8 @@
 </head>
 
 <body>
-	<a href="/">ヘッダー</a><br>
+	<a href="/">TOP</a>　
+	<a href="/menu">MENU</a><br>
     <div th:replace="${template}"/>
 
     <script th:src="@{/webjars/jquery/jquery.min.js}"></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,9 +3,9 @@
 
 <body>
 	楽天証券の配当金・分配金一覧csvファイルを選択してください
-	<form action="/table" method="post" enctype="multipart/form-data">
+	<form action="/menu" method="post" enctype="multipart/form-data">
 		<input type="file" name="csv_file"  accept=".csv">
-		<button type="submit">一覧表示する</button>
+		<button type="submit">アップロード</button>
 	</form>
 </body>
 </html>

--- a/src/main/resources/templates/menu.html
+++ b/src/main/resources/templates/menu.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'menu')}">
+
+<body>
+	menu画面<br>
+	<a href="/table">一覧表</a><br>
+	<a href="/barGraph">棒グラフ</a>
+</body>
+</html>

--- a/src/main/resources/templates/table.html
+++ b/src/main/resources/templates/table.html
@@ -3,10 +3,7 @@
 	th:replace="~{fragments/layout :: layout (~{::body},'table')}">
 
 <body>
-	一覧表
-	<form action="/barGraph" method="post" enctype="multipart/form-data">
-		<button type="submit">グラフ表示する</button>
-	</form>
+	<h1>一覧表</h1>
 	<table border="1">
     <tr>
       <th>入金日</th>


### PR DESCRIPTION
## 概要
メニュー画面を追加しました

## 修正ポイント
- CSVファイルアップロード後にメニュー画面へ遷移するようにしました
- GetとPostを整理しました
- セッションスコープの保存と読み込み部分を整理しました
- ヘッダにメニューを追加しました

## 動作確認
ローカル環境で動作確認済み
## スクリーンショット
![image](https://user-images.githubusercontent.com/53442938/105571132-c95e3400-5d90-11eb-8a8b-ebc86148557c.png)
