### PR TITLE
データがない場合はメニューへ遷移しないように変更

### DIFF
--- a/src/main/java/com/example/Controller/MenuController.java
+++ b/src/main/java/com/example/Controller/MenuController.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,12 +36,19 @@ public class MenuController {
 	public String index(@RequestParam("csv_file") MultipartFile csv_file, Map<String, Object> model) {
 		List<DividendDto> contents = menuLogic.fileContents(csv_file);
 		session.setAttribute("dividendDtoList", contents);
+		if(CollectionUtils.isEmpty(contents)) { //データがあるかどうかチェック
+			return "redirect:/";
+		}
 		return "menu";
 	}
 
 	@GetMapping
-	public String indexGet(Map<String, Object> model) {
-		//データがあるかどうかチェック
+	public String index(Map<String, Object> model) {
+		@SuppressWarnings("unchecked")
+		List<DividendDto> contents = (List<DividendDto>) session.getAttribute("dividendDtoList");
+		if(CollectionUtils.isEmpty(contents)) {
+			return "redirect:/";
+		} //本当はフィルターで実装したい
 		return "menu";
 	}
 }

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -54,7 +55,7 @@ public class Main {
 		SpringApplication.run(Main.class, args);
 	}
 
-	@RequestMapping("/")
+	@RequestMapping(path = "/", method = { RequestMethod.GET, RequestMethod.POST })
 	String index() {
 		session.invalidate(); // セッションクリア
 		return "index";


### PR DESCRIPTION
## 概要
データが読みこまれていなくてもグラフ表示画面に遷移できる状態になっている。
データなしで表示してもエラー文が表示されるだけであるため、遷移しないようにしたい

## 修正ポイント
- トップページをGETリクエストに対応させました
- メニュー画面へ遷移する前にセッションスコープを見て、データがあるかチェックするようにしました
  - データがない場合はトップページへ遷移するようにしました

## 動作確認
- ローカル環境で動かし、データが選択されていないor（選択されていても空or読みこめていない）場合は画面遷移しないことを確認済み
- データ選択時は正常に遷移することを確認済み