### PR TITLE
折れ線グラフを追加して累計配当受取額を表示

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
   <artifactId>radiviewer</artifactId>
-  <version>0.1.1</version>
+  <version>0.2.0</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/Controller/LineGraphController.java
+++ b/src/main/java/com/example/Controller/LineGraphController.java
@@ -1,0 +1,44 @@
+/**
+ *
+ */
+package com.example.Controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.Dto.DividendDto;
+import com.example.Dto.DividendDtoList;
+import com.example.Logic.LineGraphLogic;
+
+/**
+ * @author fukumura
+ *
+ */
+@Controller
+@RequestMapping("/lineGraph")
+public class LineGraphController {
+	LineGraphLogic lineGraphLogic = new LineGraphLogic();
+
+	@Autowired
+	DividendDtoList dividendDtoList;
+
+	@GetMapping
+	public String index(Map<String, Object> model) {
+
+		List<DividendDto> contents = dividendDtoList.getDividendDtoList(); // 取得
+
+		String[] year = {"2019","2020","2021"}; // 表示する年を指定
+
+		if (contents != null) {
+			String deta = lineGraphLogic.getCartData( contents, year );
+			model.put("deta", deta); // html側にデータ送るやつ
+		}
+
+		return "lineGraph";
+	}
+}

--- a/src/main/java/com/example/Logic/LineGraphLogic.java
+++ b/src/main/java/com/example/Logic/LineGraphLogic.java
@@ -1,0 +1,171 @@
+/**
+ *
+ */
+package com.example.Logic;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.example.Dto.DividendDto;
+
+/**
+ * @author fukumura
+ *
+ */
+public class LineGraphLogic {
+	/**
+	 * 配当情報リストから円グラフの描画に必要な情報を取り出します
+	 * @param dividendDtoList 配当情報リスト
+	 * @return deta 配当額の情報
+	 */
+	public String getCartData( List<DividendDto> dividendDtoList, String[] year ) {
+		List<DividendDto> contents = new ArrayList<DividendDto>();
+		List<BigDecimal[]> dataList = new ArrayList<BigDecimal[]>();
+
+		for(DividendDto dividendDto : dividendDtoList){
+			DividendDto tmpDividendDto = new DividendDto(); // newが必要
+			tmpDividendDto.setAll(dividendDto.getAll());
+			contents.add(tmpDividendDto);
+		} // sessionの値が書き換わる問題の回避策として追加
+
+		contents = exchange(contents); //ドルを円に変換
+
+		BigDecimal[] firstCartData = createCartData( contents, year[0] ); // グラフ描画用データ
+		dataList.add(firstCartData); // 1つ目のデータを追加
+
+		for(int i = 1; i < year.length; i++) { //2つ目移行のデータを追加
+			BigDecimal[] nextCartData = createCartData( contents, year[i] );//year[i] ); // グラフ描画用データ
+			dataList.add(nextCartData);
+		}
+		String deta = strComposition(createCumulativeList(dataList));
+
+		return deta;
+	}
+
+	/**
+	 * 累計額のリストを作成して返す
+	 * @param dataList 毎月の配当データ入り年別の配列のリスト
+	 * @return result 累計受取額のリスト
+	 */
+	public List<BigDecimal> createCumulativeList(List<BigDecimal[]> dataList ) {
+		List<BigDecimal> result = new ArrayList<BigDecimal>();
+		BigDecimal sum = new BigDecimal("0"); // 累計額
+		BigDecimal num = new BigDecimal("0"); // 各月の配当額
+		// 累計になるように合成して返す
+		for(BigDecimal[] dataArray : dataList){
+			for(int i = 0; i < dataArray.length; i++) {
+				num = sum.add(dataArray[i]); //累計＋現在の値
+				result.add(num); // リストに加える
+				sum = sum.add(dataArray[i]); //累計額を更新
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * 月ごとの配当受取額を配列で取得します
+	 * @param dividendDtoList 配当情報リスト
+	 * @param year 情報を得たい年
+	 * @return 月別配当受取額情報
+	 */
+	public BigDecimal[] createCartData( List<DividendDto> dividendDtoList, String year ) {
+
+		String paymentDay = ""; // 配当受取日 例）2020/11/22
+		int month = 0; // 配当受取月
+		BigDecimal[] cartData = new BigDecimal[12]; // 月毎の配当受取額格納用
+		Arrays.fill(cartData, new BigDecimal("0")); // 配列の初期化
+
+		for(DividendDto dividendDto : dividendDtoList){
+
+			paymentDay = dividendDto.getPaymentDay(true); // 配当受取日情報取得
+			String[] splitDay = paymentDay.split("/", 0); // スラッシュで分割して格納
+			month = Integer.parseInt(splitDay[1]); // 受取月をint型に変換
+			BigDecimal afterTaxDividendIncome = dividendDto.getAfterTaxDividendIncome();
+
+			if(year.equals(splitDay[0])) { // 指定されている年と一致したら
+				switch (month){ // 配当受取月で分岐
+				  case 1:
+					  cartData[0] = cartData[0].add(afterTaxDividendIncome);
+					  break;
+				  case 2:
+					  cartData[1] = cartData[1].add(afterTaxDividendIncome);
+					  break;
+				  case 3:
+					  cartData[2] = cartData[2].add(afterTaxDividendIncome);
+					  break;
+				  case 4:
+					  cartData[3] = cartData[3].add(afterTaxDividendIncome);
+					  break;
+				  case 5:
+					  cartData[4] = cartData[4].add(afterTaxDividendIncome);
+					  break;
+				  case 6:
+					  cartData[5] = cartData[5].add(afterTaxDividendIncome);
+					  break;
+				  case 7:
+					  cartData[6] = cartData[6].add(afterTaxDividendIncome);
+					  break;
+				  case 8:
+					  cartData[7] = cartData[7].add(afterTaxDividendIncome);
+					  break;
+				  case 9:
+					  cartData[8] = cartData[8].add(afterTaxDividendIncome);
+					  break;
+				  case 10:
+					  cartData[9] = cartData[9].add(afterTaxDividendIncome);
+					  break;
+				  case 11:
+					  cartData[10] = cartData[10].add(afterTaxDividendIncome);
+					  break;
+				  case 12:
+					  cartData[11] = cartData[11].add(afterTaxDividendIncome);
+					  break;
+				  default:
+					    System.out.println("[ERROR]：LineGraphLogic.createCartData");
+				}
+			}
+		}
+		return cartData; // 指定された年の月毎配当受取額情報
+	}
+
+	/**
+	 * リストで受け取った情報をコンマ区切りで文字列に合成します<br>
+	 * 戻り値の例）1,2,3,4,5
+	 * @param cartData 合成したい情報
+	 * @return result 合成した文字列
+	 */
+	public String strComposition( List<BigDecimal> cartData ) {
+		String result = "";
+		result += cartData.get(0).toString();
+		for(int i = 1; i < cartData.size(); i++) {
+			result += ",";
+			result += cartData.get(i).toString();
+		}
+		return result;
+	}
+
+	/**
+	 * ドルは円にして、円は円のまま数値を返します
+	 * @param dividendDto 配当情報リスト
+	 * @return afterTaxDividendIncome 税引き後、為替適用後配当受取額
+	 */
+	public List<DividendDto> exchange(List<DividendDto> dividendDtoList) {
+		DividendDto dividendDto = new DividendDto();
+		BigDecimal afterTaxDividendIncome = new BigDecimal(0);
+		BigDecimal exchangeRate = new BigDecimal(100); // 為替レート
+
+		for(int i = 0; i < dividendDtoList.size(); ++i){
+			dividendDto = dividendDtoList.get(i);
+
+			if("米国株式".contentEquals(dividendDto.getProduct())) {
+				afterTaxDividendIncome = dividendDto.getAfterTaxDividendIncome();
+				afterTaxDividendIncome = afterTaxDividendIncome.multiply(exchangeRate); // 掛け算
+				dividendDtoList.get(i).setAfterTaxDividendIncome(afterTaxDividendIncome);
+			}
+		}
+		return dividendDtoList;
+	}
+
+}

--- a/src/main/resources/templates/lineGraph.html
+++ b/src/main/resources/templates/lineGraph.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{fragments/layout :: layout (~{::body},'lineGraph')}">
+
+<body>
+	<h1>線グラフ</h1>
+	USD/JPY 100 で計算しています。
+	<br>
+	<canvas id="lineChart"></canvas>
+	<script
+		src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+
+	<script>
+		var ctx = document.getElementById("lineChart");
+		var myLineChart = new Chart(ctx, {
+			type : 'line',
+			data : {
+				labels : [ '2019年1月', '2月', '3月', '4月', '5月',
+					'6月', '7月', '8月', '9月', '10月', '11月', '12月',
+					'2020年1月', '2月', '3月', '4月', '5月', '6月'
+					, '7月', '8月', '9月', '10月', '11月', '12月'
+					, '2021年1月'],
+				datasets : [ {
+					label : '累計配当受取額(円）',
+					data : [ [[${deta}]] ],
+					borderColor : "rgba(0,0,255,1)",
+					backgroundColor : "rgba(0,0,0,0)"
+				} ],
+			},
+			options : {
+				title : {
+					display : true,
+					text : '配当推移（2019年1月~2021年1月）'
+				},
+				scales : {
+					yAxes : [ {
+						ticks : {
+							suggestedMax : 40,
+							suggestedMin : 0,
+							stepSize : 10,
+							callback : function(value, index, values) {
+								return value + '円'
+							}
+						}
+					} ]
+				},
+			}
+		});
+	</script>
+</body>
+</html>

--- a/src/main/resources/templates/menu.html
+++ b/src/main/resources/templates/menu.html
@@ -10,5 +10,7 @@
 	<a href="/barGraph">棒グラフ</a>
 	<br>
 	<a href="/pieGraph">円グラフ</a>
+	<br>
+	<a href="/lineGraph">線グラフ</a>
 </body>
 </html>


### PR DESCRIPTION
## 概要
線グラフ描画機能を実装します
線グラフは配当推移（累計値）を表します

## 修正ポイント
- 線グラフ用のMVCを追加
- メニューに線グラフを追加
- マイナーバージョンアップ

## 動作確認
ローカルで実際に動かして正常に動作することを確かめました