### PR TITLE
グラフ画面のレスポンシブ対応

### DIFF
--- a/src/main/resources/public/stylesheets/main.css
+++ b/src/main/resources/public/stylesheets/main.css
@@ -1,17 +1,38 @@
+/* # メニュー画面CSS */
 .menu-img {
 	text-align : center
 }
-
+/* - PC用 */
 @media (min-width: 767px) {
 	.menu-img img {
 		width: 22vw;
 		margin: 1%;
 	}
 }
-
+/* - スマホ用 */
 @media (max-width: 768px) {
 	.menu-img img {
 		width: 40vw;
 		margin: 2%;
 	}
 }
+
+/* # グラフ画面CSS */
+/* - PC用 */
+@media (min-width: 767px) {
+	.chart-container {
+	position: relative;
+	width: 100vw;
+	height: 600px;
+	}
+}
+/* - スマホ用 */
+@media (max-width: 768px) {
+	.chart-container {
+	position: relative;
+	width: 100vw;
+	height: 400px;
+	}
+}
+
+

--- a/src/main/resources/templates/barGraph.html
+++ b/src/main/resources/templates/barGraph.html
@@ -6,7 +6,9 @@
 	<h1>棒グラフ</h1>
 	USD/JPY 100 で計算しています。
 	<br>
+	<div class="chart-container">
 	<canvas id="barChart"></canvas>
+	</div>
 	<script
 		src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
 

--- a/src/main/resources/templates/barGraph.html
+++ b/src/main/resources/templates/barGraph.html
@@ -48,6 +48,7 @@
 						}
 					} ]
 				},
+				maintainAspectRatio: false,
 			}
 		});
 	</script>

--- a/src/main/resources/templates/lineGraph.html
+++ b/src/main/resources/templates/lineGraph.html
@@ -6,7 +6,9 @@
 	<h1>線グラフ</h1>
 	USD/JPY 100 で計算しています。
 	<br>
+	<div class="chart-container">
 	<canvas id="lineChart"></canvas>
+	</div>
 	<script
 		src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
 

--- a/src/main/resources/templates/lineGraph.html
+++ b/src/main/resources/templates/lineGraph.html
@@ -44,6 +44,7 @@
 						}
 					} ]
 				},
+				maintainAspectRatio: false,
 			}
 		});
 	</script>

--- a/src/main/resources/templates/pieGraph.html
+++ b/src/main/resources/templates/pieGraph.html
@@ -27,7 +27,8 @@
 				title : {
 					display : true,
 					text : '銘柄別  配当受取額割合'
-				}
+				},
+				maintainAspectRatio: false,
 			}
 		});
 	</script>

--- a/src/main/resources/templates/pieGraph.html
+++ b/src/main/resources/templates/pieGraph.html
@@ -7,7 +7,9 @@
 	単位：円<br>
 	USD/JPY 100 で計算しています。
 	<br>
+	<div class="chart-container">
 	<canvas id="pieChart"></canvas>
+	</div>
 	<script
 		src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
 


### PR DESCRIPTION
## 概要
グラフ描画画面をスマホでの表示に対応させる

## 修正ポイント
- チャートのオプションで固定アスペクト比を解除
  - 公式サイトを参照して作成
- チャートの高さと幅を指定するCSS追加

## 動作確認
エミュレータ、スマホ、PCで画面表示してグラフ表示されることを確認しました
サイズ感も問題ありません